### PR TITLE
Write real tests with real assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: haskell
+
+ghc:
+  - 8.0
+  - 7.10
+  - 7.8
+  - 7.6

--- a/sqlite.cabal
+++ b/sqlite.cabal
@@ -56,7 +56,7 @@ library
 
 test-suite sqlite-tests
   Type:            exitcode-stdio-1.0
-  Build-depends:   base, sqlite
+  Build-depends:   base, sqlite, temporary, filepath, hspec >=2.0 && <3.0
   Main-is:         Main.hs
   hs-source-dirs:  tests/
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -10,22 +10,25 @@ newTable tName =
   VirtualTable
         { tabName    = tName
         , tabColumns =
-	    [ Column { colName    = "id"
-	             , colType    = SQLInt NORMAL False False
-		     , colClauses = [PrimaryKey True]
-		     }
-	    , Column { colName    = "name"
-	             , colType    = SQLVarChar 200
-		     , colClauses = [IsNullable False]
-		     }
-	    , Column { colName    = "age"
-	             , colType    = SQLVarChar 200
-		     , colClauses = [IsNullable True]
-		     }
-            ]
+              [ Column { colName    = "id"
+                       , colType    = SQLInt NORMAL False False
+                       , colClauses = [PrimaryKey True]
+                       }
+
+              , Column { colName    = "name"
+                       , colType    = SQLVarChar 200
+                       , colClauses = [IsNullable False]
+                       }
+
+              , Column { colName    = "age"
+                       , colType    = SQLVarChar 200
+                       , colClauses = [IsNullable True]
+                       }
+              ]
+
         , tabConstraints = []
         , tabUsing = "FTS3"
-	}
+        }
 
 main :: IO ()
 main = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,9 +1,14 @@
 module Main where
 
-import Database.SQLite
-import System.IO.Error (catchIOError)
+import Control.Exception.Base (bracket)
+import Data.Maybe
+import System.FilePath ((</>))
+import System.IO.Temp (withTempDirectory)
+import Test.Hspec
+import Text.Printf (printf)
 
-catch = catchIOError
+import Database.SQLite
+
 
 newTable :: TableName -> Table SQLType
 newTable tName =
@@ -30,38 +35,86 @@ newTable tName =
         , tabUsing = "FTS3"
         }
 
-main :: IO ()
-main = do
-  let dbFile = "tests/test.db"
-  let ign act =
-        catch (act >> return ())
-              (\ err -> putStrLn ("Error (but ignoring) -- " ++ show err) >> return ())
-  h <- openConnection dbFile
-  ign $ defineTable h (newTable "names")
-  --
-  ign $ insertRow h "Poststed" [("Postnr", "4278"),("Poststed", "Veakrossen")]
-  ls <- execStatement h "SELECT * FROM Poststed WHERE PostNr=4276;"
-  print (ls :: Either String [[Row Value]])
-  --
-  ign $ insertRow h "names" [("id", "2357"), ("name", "1,5m bis 3,0m"), ("age","35")]
-  -- This test a bug reported by Nikolas Mayr
-  ls <- execStatement h "SELECT * FROM names WHERE id=2357;"
-  print (ls :: Either String [[Row Value]])
-  --
-  ign $ insertRow h "names" [("id", "1"),("name", "foo"), ("age", "30")]
-  ls <- execStatement h "SELECT * FROM names;"
-  print (ls :: Either String [[Row String]])
-  --
-  ls <- execStatement h "SELECT * FROM names where id=1;"
-  print (ls :: Either String [[Row String]])
-  --
-  createFunction h "hi" (sum :: [Int] -> Int)
-  ls <- execStatement h "SELECT hi(1,2,3,4,5) AS greeting"
-  print (ls :: Either String [[Row String]])
-  --
-  createFunction h "say" putStrLn
-  ls <- execStatement h "SELECT say('Hi') AS greeting"
-  print (ls :: Either String [[Row String]])
-  --
-  closeConnection h
+withDB :: FilePath -> (SQLiteHandle -> IO a) -> IO a
+withDB dbName = bracket (openConnection dbName) closeConnection
 
+withTempDB :: (SQLiteHandle -> IO a) -> IO a
+withTempDB f =
+    withTempDirectory "tmp" "test." $ \dirname ->
+    let dbName = dirname </> "database.sqlite3" in
+    withDB dbName f
+
+
+withTempTable :: (String -> SQLiteHandle -> IO a) -> IO a
+withTempTable f = withTempDB $ \h ->
+    let tab = "names" in
+    defineTable h (newTable "names") >> f tab h
+
+
+flatExecStatement :: SQLiteResult a => SQLiteHandle -> String -> IO (Either String [Row a])
+flatExecStatement h sqlStmt =
+    let flattenResults = concat
+        mapResult f (Right r) = Right (f r)
+        mapResult f (Left l) = Left l
+
+    in mapResult flattenResults <$> execStatement h sqlStmt
+
+
+insertManyRows :: SQLiteHandle -> String -> [Row String] -> IO (Maybe String)
+insertManyRows h tab rows = chain insertions
+    where insertions   = map (insertRow h tab) rows
+
+          chain []     = return Nothing
+          chain (i:is) = do
+            r <- i
+            case r of
+                Nothing -> chain is
+                Just err -> return $ Just err
+
+
+spec :: Spec
+spec = parallel $ do
+    describe "execStatement and execStatement_" $ do
+        it "runs select statements" $ withTempDB $ \h -> do
+            result <- flatExecStatement h "SELECT 'Hello, World' AS h"
+            result `shouldBe` Right [[("h", "Hello, World")]]
+
+        it "fails on bad SQL" $ withTempDB $ \h -> do
+            error <- execStatement_ h "SELECT aieauie"
+            error `shouldSatisfy` isJust
+
+
+    describe "insertRow" $ do
+        it "stores data" $ withTempTable $ \tab h -> do
+            let row = [("id", "1"), ("name", "John Doe"), ("age", "45")]
+            error <- insertRow h tab row
+            error `shouldSatisfy` isNothing
+
+            ls <- flatExecStatement h $ printf "SELECT * FROM %s" tab
+            ls `shouldBe` Right [row]
+
+
+        it "can be called many times" $ withTempTable $ \tab h -> do
+            let rows = [ [ ("id", "1"), ("name", "Erika Munstermann"), ("age", "28") ]
+                       , [ ("id", "2"), ("name", "Max Munstermann"), ("age", "24") ]
+                       ]
+            error <- insertManyRows h tab rows
+            error `shouldSatisfy` isNothing
+
+            ls <- flatExecStatement h $ printf "SELECT * FROM %s ORDER BY id" tab
+            ls `shouldBe` Right rows
+
+
+        it "fails on bad row insertion" $ withTempTable $ \tab h -> do
+            error <- insertRow h tab [("foo", "bar")]
+            error `shouldSatisfy` isJust
+
+    describe "createFunction" $ do
+        it "runs haskell code" $ withTempDB $ \h -> do
+            createFunction h "hi" (sum :: [Int] -> Int)
+            ls <- flatExecStatement h "SELECT hi(1, 2, 3, 4, 5) AS greeting"
+            ls `shouldBe` Right [[("greeting", show $ sum [1, 2, 3, 4, 5])]]
+
+
+main :: IO ()
+main = hspec spec

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The old tests were just displaying stuff...

This uses `hspec` to assert things, and run tests in parallel.

This also makes tests stateless since each test create its own database, and its own data.