### PR TITLE
Add status code to query (and some other fixes)

### DIFF
--- a/Database/SQLite.hs
+++ b/Database/SQLite.hs
@@ -316,12 +316,7 @@ execStatement db s = execParamStatement db s []
 
 -- | Returns an error, or 'Nothing' if everything was OK.
 execStatement_ :: SQLiteHandle -> String -> IO (Maybe String)
-execStatement_ h sqlStmt = withPrim h $ \ db ->
-  withUtf8CString sqlStmt $ \ c_sqlStmt ->
-  sqlite3_exec db c_sqlStmt noCallback nullPtr nullPtr >>= \ st ->
-  if st == sQLITE_OK
-    then return Nothing
-    else fmap Just . peekUtf8CString =<< sqlite3_errmsg db
+execStatement_ db s = execParamStatement_ db s []
 
 tupled :: [String] -> String
 tupled xs = "(" ++ concat (intersperse ", " xs) ++ ")"

--- a/Database/SQLite.hs
+++ b/Database/SQLite.hs
@@ -110,7 +110,7 @@ openConnection dbName =
 -- | Open a new database connection read-only, whose name is given
 -- by the 'dbName' argument. A sqlite3 handle is returned.
 --
--- An exception is thrown if the database does not exist, 
+-- An exception is thrown if the database does not exist,
 -- or could not be opened.
 --
 openReadonlyConnection :: String -> IO SQLiteHandle
@@ -472,7 +472,7 @@ type Arity = Int
 type FunctionName = String
 type FunctionHandler = SQLiteContext -> [SQLiteValue] -> IO ()
 
-class IsFunctionHandler a where 
+class IsFunctionHandler a where
     funcArity   :: a -> Arity
     funcHandler :: a -> FunctionHandler
 
@@ -617,13 +617,13 @@ set_aggr_context ctx x = do
 
 _SZ :: CInt
 _SZ = toEnum $ sizeOf nullPtr
- 
+
 step_callback :: IsValue v => a -> (a -> [v] -> IO a) -> StepHandler
 step_callback x f ctx argc argv = do
     args <- peekArray (fromEnum argc) argv
     aVal <- get_aggr_context x ctx
     newVal <- f aVal =<< mapM fromSQLiteValue args
-    set_aggr_context ctx newVal 
+    set_aggr_context ctx newVal
 
 createAggregatePrim :: (IsValue i, IsValue o) => SQLiteHandle -> FunctionName -> Arity -> (a -> [i] -> IO a) -> a -> (a -> IO o) -> IO ()
 createAggregatePrim h name arity step x finalize = do
@@ -642,7 +642,7 @@ createAggregatePrim h name arity step x finalize = do
                    finalizeFunc
     addSQLiteHandleFinalizer h (freeCallback stepFunc)
     addSQLiteHandleFinalizer h (freeCallback finalizeFunc)
-    
+
 class IsValue a where
     fromSQLiteValue     :: SQLiteValue -> IO a
     returnSQLiteValue   :: SQLiteContext -> a -> IO ()

--- a/Database/SQLite.hs
+++ b/Database/SQLite.hs
@@ -309,7 +309,20 @@ execParamStatement h query params = withPrim h $ \ db ->
       Left _ -> to_error db
       Right r -> return (Right r)
 
--- | Evaluate the SQL statement specified by 'sqlStmt'
+-- | Evaluate the SQL statement specified by 's'
+--
+-- Results have two levels of nesting because multiple SQL statements can be
+-- executed in order. These statements are separated by semi-colon.
+--
+-- Examples:
+--
+-- >>> :set -XScopedTypeVariables
+-- >>> let h = openConnection ":memory:"
+-- >>> execStatement h "CREATE TABLE foo(bar int)"
+-- >>> execStatement h "INSERT INTO foo(bar) VALUES (1), (2)"
+-- >>> execStatement h "SELECT bar as a FROM foo ORDER BY 1; SELECT 1 as b, 2 as c"
+-- Right [[[("a", "1")], [("a", "2")]], [[("b", "1), ("c", "2")]]]
+--
 execStatement :: SQLiteResult a
                => SQLiteHandle -> String -> IO (Either String [[Row a]])
 execStatement db s = execParamStatement db s []

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -62,6 +62,12 @@ insertManyRows h tab rows = chain insertions
                 Nothing -> chain is
                 Just err -> return $ Just err
 
+-- Some tests only test only test the error code, therefore Haskell can't resolve the
+-- SQLiteResult instance. This forces it to be a String.
+execStatementWithStatusCode' :: SQLiteHandle -> String
+                             -> IO (Either SQLiteErrorWithCode [[Row String]])
+execStatementWithStatusCode' = execStatementWithStatusCode
+
 
 spec :: Spec
 spec = parallel $ do
@@ -127,6 +133,12 @@ spec = parallel $ do
 
             result <- query [(":pattern", Text "Erika%")]
             result `shouldBe` Right [[[("name", "Erika Munstermann")]]]
+
+
+    describe "execParamStatementWithStatusCode" $ do
+        it "returns the status code from SQLite" $ withTempDB $ \h -> do
+            Left error <- execStatementWithStatusCode' h "SELECT nasuitenarusie"
+            fst error `shouldBe` sQLITE_ERROR
 
 
 main :: IO ()


### PR DESCRIPTION
I'm not sure if I should do multiple pull requests for this. I made multiple fixes, and one of them 

* I added tests for parametrization, just in case.
* Also, I removed duplicated code when running SQL statements.
* I removed trailing white spaces (because my editor doesn't like them, and I think most people are like my editor)

But what I wanted to do originally, is just add an api to run statements and get the status code in case of error. (this is done by `execStatementWithStatusCode` and `execParamStatementWithStatusCode`)

This also fix #4 since it documents why `[[Row a]]` is nested two level deep.

Also I wanted to thank you for reviewing and merging my pull requests so fast.

Let me know if there's anything to change.